### PR TITLE
Add stemming-based item search normalization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-SQLAlchemy==3.1.1
 pandas==2.2.2
 scikit-learn==1.4.2
 joblib==1.3.2
+nltk==3.8.1


### PR DESCRIPTION
## Summary
- use PorterStemmer to normalize search tokens so plurals like "dress"/"dresses" match
- fall back to manual plural heuristics when NLTK is unavailable
- add nltk to requirements

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `python - <<'PY'\nimport app\nprint(app.normalize_token('dresses'))\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68becd4e35f48322a8a55a8c21d9e1d2